### PR TITLE
Update footer year to 2025

### DIFF
--- a/Link2App/Info.plist
+++ b/Link2App/Info.plist
@@ -29,6 +29,6 @@
 		<true/>
 	</dict>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2024 Link2App. All rights reserved.</string>
+	<string>Copyright © 2025 Link2App. All rights reserved.</string>
 </dict>
 </plist>

--- a/docs/index.html
+++ b/docs/index.html
@@ -740,7 +740,7 @@ struct ContentView: View {
           </div>
         </div>
         <div class="footer-bottom">
-          <p>&copy; 2024 Link2App. All rights reserved.</p>
+          <p>&copy; 2025 Link2App. All rights reserved.</p>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
Update copyright year to 2025 in documentation and iOS app configuration.

---
<a href="https://cursor.com/background-agent?bcId=bc-055ec89d-11f7-4873-8e43-af2a70f14bd2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-055ec89d-11f7-4873-8e43-af2a70f14bd2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

